### PR TITLE
Extending xmlchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 _scratch/
 Session.vim
 /.tox/
+.vscode/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,8 @@ rst_epilog = """
 
 .. |AttributeError| replace:: :exc:`.AttributeError`
 
+.. |BaseOxmlElement| replace:: :class:`.BaseOxmlElement`
+
 .. |BaseStyle| replace:: :class:`.BaseStyle`
 
 .. |BlockItemContainer| replace:: :class:`.BlockItemContainer`
@@ -124,6 +126,8 @@ rst_epilog = """
 .. |InlineShapes| replace:: :class:`.InlineShapes`
 
 .. |InvalidSpanError| replace:: :class:`.InvalidSpanError`
+
+.. |InvalidXmlError| replace:: :class:`.InvalidXmlError`
 
 .. |int| replace:: :class:`.int`
 

--- a/docs/dev/analysis/index.rst
+++ b/docs/dev/analysis/index.rst
@@ -33,3 +33,11 @@ ISO/IEC 29500 spec.
    schema/ct_document
    schema/ct_body
    schema/ct_p
+
+XMLChemy
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   xmlchemy

--- a/docs/dev/analysis/xmlchemy.rst
+++ b/docs/dev/analysis/xmlchemy.rst
@@ -1,0 +1,275 @@
+
+Understanding ``xmlchemy``
+==========================
+
+``xmlchemy`` is an object-XML mapping layer somewhat reminiscent of
+SQLAlchemy, hence the name. Mapping XML elements to objects is not nearly as
+challenging as mapping to a relational database, so this layer is
+substantially more modest. Nevertheless, it provides a powerful and very
+useful abstraction layer around ``lxml``, particularly well-suited to
+providing access to the broad schema of XML elements involved in the Open XML
+standard.
+
+
+Additional topics to add ...
+----------------------------
+
+* understanding complex types in Open XML
+* understanding attribute definitions Open XML
+* understanding simple types in Open XML
+
+
+Adding support for a new element type
+-------------------------------------
+
+* add a new custom element mapping to ``pptx.oxml.__init__``
+* add a new custom element class in the appropriate ``pptx.oxml`` subpackage
+  module
+* Add element definition members to the class
+* Add attribute definition members to the class
+* Add simple type definitions to ``pptx.oxml.simpletype``
+
+Complex Types
+-------------
+
+XML Complex Types are XML elements that contain other elements and/or attributes.
+You can implement complex types in ``xmlchemy`` by:
+
+* Creating a class that inherits from |BaseOxmlElement|. Assign the appropiate child 
+  elements and attributes as class variables. 
+* Register the the class to it's tag. By convention, this is done for all elements 
+  in ``docx.oxml.__init__``. Just call ``register_element_cls(namespaced_tagname, element_class)``
+
+You can add whatever helper methods (class and or normal) to the element class as you 
+see fit.
+
+The |BaseOxmlElement| inheritance will auto-generate a variety of helper methods and 
+properties for each of the child element and attributes that you've defined on the
+element class. 
+
+Child elements are one of the following types:
+
+``Choice``
+    Defines a child belonging to a group, only one of which may appear. 
+
+``OneAndOnlyOne``
+    Defines a required child element. See :ref:`OneAndOnlyOne-declaration`.
+
+``OneOrMore``
+    Defines a repeating child element that must appear at least once.
+
+``ZeroOrMore``
+    Defines an optional repeating child element. See :ref:`ZeroOrMore-declaration`.
+
+``ZeroOrOne``
+    Defines an optional child element. See See :ref:`ZeroOrOne-declaration`.
+
+``ZeroOrOneChoice``
+    Defines a child belonging to a group, where at most only one of which may appear.
+
+See ``class CT_Foobar`` in the example below for an example custom
+
+Example
+-------
+
+::
+
+    from pptx.oxml.xmlchemy import BaseOxmlElement
+
+
+    class CT_Foobar(BaseOxmlElement):
+        """
+        Custom element class corresponding to ``CT_Foobar`` complex type
+        definition in pml.xsd or other Open XML schema.
+        """
+        hlink = ZeroOrOne('a:hlink', successors=('a:rtl', 'a:extLst'))
+        eg_fillProperties = ZeroOrOneChoice(
+            (Choice('a:noFill'), Choice('a:solidFill'), Choice('a:gradFill'),
+             Choice('a:blipFill'), Choice('a:pattFill')),
+            successors=(
+                'a:effectLst', 'a:effectDag', 'a:highlight', 'a:uLnTx',
+                'a:uLn', 'a:uFillTx' 'a:extLst'
+            )
+        )
+
+        sz = OptionalAttribute(
+            'sz', ST_SimpleType, default=ST_SimpleType.OPTION
+        )
+        anchor = OptionalAttribute('i', XsdBoolean)
+        rId = RequiredAttribute('r:id', XsdString)
+
+
+Protocol
+--------
+
+::
+
+    >>> assert isinstance(foobar, CT_Foobar)
+    >>> foobar.hlink
+    None
+    >>> hlink = foobar._add_hlink()
+    >>> hlink
+    <pptx.oxml.xyz.CT_Hyperlink object at 0x10ab4b2d0>
+    >>> assert foobar.hlink is hlink
+
+    >>> foobar.eg_fillProperties
+    None
+    >>> foobar.solidFill
+    None
+    >>> solidFill = foobar.get_or_change_to_solidFill()
+    >>> solidFill
+    <pptx.oxml.xyz.CT_SolidFill object at 0x10ab4b2d0>
+    >>> assert foobar.eg_fillProperties is solidFill
+    >>> assert foobar.solidFill is solidFill
+    >>> foobar.remove_eg_fillProperties()
+    >>> foobar.eg_fillProperties
+    None
+    >>> foobar.solidFill
+    None
+
+.. _OneAndOnlyOne-declaration:
+
+``OneAndOnlyOne`` element declaration
+-------------------------------------
+
+The ``OneAndOnlyOne`` callable generates the API for a required child
+element::
+
+    childElement = OneAndOnlyOne('ns:localTagName')
+
+Unlike the other element declarations, the call does not include
+a ``successors`` argument. Since no API for inserting a new element is
+generated, a successors list is not required.
+
+
+Generated API
+~~~~~~~~~~~~~
+
+``childElement`` property (read-only)
+    Holds a reference to the child element object. Raises |InvalidXmlError|
+    on access if the required child element is not present.
+
+
+Protocol
+~~~~~~~~
+
+::
+
+    >>> foobar.childElement
+    <pptx.oxml.xyz.CT_ChildElement object at 0x10ab4b2d0>
+
+
+``RequiredAttribute`` attribute declaration
+-------------------------------------------
+
+::
+
+    reqAttr = RequiredAttribute('reqAtr', ST_SimpleType)
+
+
+Generated API
+~~~~~~~~~~~~~
+
+``childElement`` property (read/write)
+    Referencing the property returns the type-converted value of the
+    attribute as determined by the ``from_xml()`` method of the simple type
+    class appearing in the declaration (e.g. ST_SimpleType above).
+    Assignments to the property are validated by the ``validate()`` method of
+    the simple type class, potentially raising ``TypeError`` or
+    ``ValueError``. Values are assigned in their natural Python type and are
+    encoded to the appropriate string value by the ``to_xml()`` method of the
+    simple type class.
+
+
+.. _ZeroOrOne-declaration:
+
+``ZeroOrOne`` element declaration
+---------------------------------
+
+::
+
+    childElement = ZeroOrOne(
+        'ns:localTagName', successors=('ns:abc', 'ns:def')
+    )
+
+
+Generated API
+~~~~~~~~~~~~~
+
+``childElement`` property (read-only)
+    Holds a reference to the child element object, or None if the element is
+    not present.
+
+``get_or_add_childElement()`` method
+    Returns the child element object, newly added if not present.
+
+``set_childElement(childElement)`` element setter method
+    Sets the ``childElement``, inserting it into the correct location.
+    If ``childElement`` is |None|, this method will remove the child element.
+    If ``childElement`` already exists, this method will replace it.
+
+``_add_childElement()`` empty element adder method
+    Returns a newly added empty child element having the declared tag name.
+    Adding is unconditional and assumes the element is not already present.
+    This method is called by the ``get_or_add_childElement()`` method as
+    needed and may be called by a hand-coded ``add_childElement()`` method
+    as needed. May be overridden to produce customized behavior.
+
+``_new_childElement()`` empty element creator method
+    Returns a new "loose" child element of the declared tag name. Called by
+    ``_add_childElement()`` to obtain a new child element, it may be
+    overridden to customize the element creation process.
+
+``_insert_childElement(childElement)`` element inserter method
+    Returns the passed ``childElement`` after inserting it before any
+    successor elements, as listed in the ``successors`` argument of the
+    declaration. Called by ``_add_childElement()`` to insert the new element
+    it creates using ``_new_childElement()``.
+
+``_remove_childElement()`` element remover method
+    Removes all instances of the child element. Does not raise an error if no
+    matching child elements are present.
+
+.. _ZeroOrMore-declaration:
+
+``ZeroOrMore`` element declaration
+----------------------------------
+
+::
+
+    childElement = ZeroOrMore(
+        'ns:localTagName', successors=('ns:abc', 'ns:def')
+    )
+
+Generated API
+~~~~~~~~~~~~~
+
+``{prop_name}_lst`` list getter property
+    A list containing each of child elements in the order they appear.
+
+``add_childElement(new_child=None, successor_element=None)`` public adder method
+    Inserts and return new child into list. If ``new_child`` is None, will 
+    insert a new empty element. If ``successor_element``is None, will append
+    to end of list. Otherwise, will insert ``new_child`` before ``successor_element``.
+
+``remove_childElement(target_child)`` public remove method.
+    Remove child element unconditionally. If |None| is passed in, will
+    remove all child elements.
+
+``_add_childElement()`` empty element adder method
+    Returns a newly added empty child element having the declared tag name.
+    Adding is unconditional and assumes the element is not already present.
+    This method is called by the ``get_or_add_childElement()`` method as
+    needed and may be called by a hand-coded ``add_childElement()`` method
+    as needed. May be overridden to produce customized behavior.
+
+``_new_childElement()`` empty element creator method
+    Returns a new "loose" child element of the declared tag name. Called by
+    ``_add_childElement()`` to obtain a new child element, it may be
+    overridden to customize the element creation process.
+
+``_insert_childElement(childElement)`` element inserter method
+    Returns the passed ``childElement`` after inserting it before any
+    successor elements, as listed in the ``successors`` argument of the
+    declaration. Called by ``_add_childElement()`` to insert the new element
+    it creates using ``_new_childElement()``.

--- a/docx/oxml/xmlchemy.py
+++ b/docx/oxml/xmlchemy.py
@@ -104,7 +104,6 @@ class MetaOxmlElement(type):
             if isinstance(value, dispatchable):
                 value.populate_class_members(cls, key)
 
-
 class BaseAttribute(object):
     """
     Base class for OptionalAttribute and RequiredAttribute, providing common
@@ -753,7 +752,9 @@ class _OxmlElementBase(etree.ElementBase):
     def _nsptag(self):
         return NamespacePrefixedTag.from_clark_name(self.tag)
 
+_OxmlElementBase_dict = dict(_OxmlElementBase.__dict__)
+_OxmlElementBase_dict.pop('__dict__', None)
 
 BaseOxmlElement = MetaOxmlElement(
-    'BaseOxmlElement', (etree.ElementBase,), dict(_OxmlElementBase.__dict__)
+    'BaseOxmlElement', (etree.ElementBase,), _OxmlElementBase_dict
 )

--- a/tests/opc/test_phys_pkg.py
+++ b/tests/opc/test_phys_pkg.py
@@ -43,17 +43,17 @@ class DescribeDirPkgReader(object):
 
     def it_can_retrieve_the_blob_for_a_pack_uri(self, dir_reader):
         pack_uri = PackURI('/word/document.xml')
-        blob = dir_reader.blob_for(pack_uri)
+        blob = dir_reader.blob_for(pack_uri).replace(b'\r\n', b'\n')
         sha1 = hashlib.sha1(blob).hexdigest()
         assert sha1 == '0e62d87ea74ea2b8088fd11ee97b42da9b4c77b0'
 
     def it_can_get_the_content_types_xml(self, dir_reader):
-        sha1 = hashlib.sha1(dir_reader.content_types_xml).hexdigest()
+        sha1 = hashlib.sha1(dir_reader.content_types_xml.replace(b'\r\n', b'\n')).hexdigest()
         assert sha1 == '89aadbb12882dd3d7340cd47382dc2c73d75dd81'
 
     def it_can_retrieve_the_rels_xml_for_a_source_uri(self, dir_reader):
         rels_xml = dir_reader.rels_xml_for(PACKAGE_URI)
-        sha1 = hashlib.sha1(rels_xml).hexdigest()
+        sha1 = hashlib.sha1(rels_xml.replace(b'\r\n', b'\n')).hexdigest()
         assert sha1 == 'ebacdddb3e7843fdd54c2f00bc831551b26ac823'
 
     def it_returns_none_when_part_has_no_rels_xml(self, dir_reader):

--- a/tests/oxml/test_xmlchemy.py
+++ b/tests/oxml/test_xmlchemy.py
@@ -25,6 +25,18 @@ from .unitdata.text import a_b, a_u, an_i, an_rPr
 
 class DescribeBaseOxmlElement(object):
 
+    def it_has_dir_and_has_xmlchemy_methods(self, simple_fixture):
+        element = simple_fixture
+        try:
+            dir_dict = dir(element)
+            assert "oomChild_lst" in dir_dict
+            assert "_new_oomChild" in dir_dict
+            assert "_insert_oomChild" in dir_dict
+            assert "_add_oomChild" in dir_dict
+            assert "add_oomChild" in dir_dict
+        except TypeError:
+            pytest.fail("Unexpected exception")
+
     def it_can_find_the_first_of_its_children_named_in_a_sequence(
             self, first_fixture):
         element, tagnames, matching_child = first_fixture
@@ -43,6 +55,10 @@ class DescribeBaseOxmlElement(object):
         assert element.xml == expected_xml
 
     # fixtures ---------------------------------------------
+
+    @pytest.fixture
+    def simple_fixture(self):
+        return a_simple_parent().with_nsdecls().element
 
     @pytest.fixture(params=[
         ('biu', 'iu',  'i'),
@@ -737,6 +753,11 @@ class CT_Parent(BaseOxmlElement):
     optAttr = OptionalAttribute('w:optAttr', ST_IntegerType)
     reqAttr = RequiredAttribute('reqAttr', ST_IntegerType)
 
+class CT_SimpleParent(BaseOxmlElement):
+    """
+    ``<w:simpleparent>`` element, an invented element for use in testing.
+    """
+    oomChild = OneOrMore('w:oomChild')
 
 class CT_Choice(BaseOxmlElement):
     """
@@ -767,6 +788,7 @@ class CT_ZooChild(BaseOxmlElement):
 
 
 register_element_cls('w:parent',   CT_Parent)
+register_element_cls('w:simpleparent',   CT_SimpleParent)
 register_element_cls('w:choice',   CT_Choice)
 register_element_cls('w:oomChild', CT_OomChild)
 register_element_cls('w:zomChild', CT_ZomChild)
@@ -789,6 +811,12 @@ class CT_ParentBuilder(BaseBuilder):
     __tag__ = 'w:parent'
     __nspfxs__ = ('w',)
     __attrs__ = ('w:optAttr', 'reqAttr')
+
+
+class CT_SimpleParentBuilder(BaseBuilder):
+    __tag__ = 'w:simpleparent'
+    __nspfxs__ = ('w',)
+    __attrs__ = ()
 
 
 class CT_OomChildBuilder(BaseBuilder):
@@ -825,6 +853,10 @@ def a_choice2():
 
 def a_parent():
     return CT_ParentBuilder()
+
+
+def a_simple_parent():
+    return CT_SimpleParentBuilder()
 
 
 def a_zomChild():

--- a/tests/oxml/test_xmlchemy.py
+++ b/tests/oxml/test_xmlchemy.py
@@ -386,6 +386,52 @@ class DescribeOneOrMore(object):
             'Add a new ``<w:oomChild>`` child element '
         )
 
+    def it_has_public_add_method_that_appends_to_end(self):
+        parent = a_parent().with_nsdecls().with_child(
+            an_oomChild().with_optval("val1")
+        ).element
+
+        new_child = an_oomChild().with_nsdecls().with_optval("val2").element
+
+        parent.add_oomChild(new_child)
+
+        expected_xml = a_parent().with_nsdecls().with_child(
+            an_oomChild().with_optval("val1")).with_child(
+                an_oomChild().with_optval("val2")
+            ).xml()
+
+        assert parent.xml == expected_xml
+
+    def it_has_public_add_method_that_inserts_into_sequence(self):
+        parent = a_parent().with_nsdecls().with_child(
+            an_oomChild().with_optval("val1")
+        ).element
+
+        new_child = an_oomChild().with_nsdecls().with_optval("val2").element
+
+        parent.add_oomChild(new_child, successor_element=parent.oomChild_lst[0])
+
+        expected_xml = a_parent().with_nsdecls().with_child(
+            an_oomChild().with_optval("val2")).with_child(
+                an_oomChild().with_optval("val1")
+            ).xml()
+
+        assert parent.xml == expected_xml
+
+    def it_adds_a_public_method_for_removing_specific_child_element(self):
+        parent = a_parent().with_nsdecls().with_child(
+            an_oomChild().with_optval("val1")).with_child(
+                an_oomChild().with_optval("val2")
+            ).element
+        
+        parent.remove_oomChild(parent.oomChild_lst[0])
+
+        expected_xml = a_parent().with_nsdecls().with_child(
+                an_oomChild().with_optval("val2")
+            ).xml()
+
+        assert parent.xml == expected_xml
+
     # fixtures -------------------------------------------------------
 
     @pytest.fixture
@@ -556,7 +602,7 @@ class DescribeZeroOrMore(object):
             'Add a new ``<w:zomChild>`` child element '
         )
 
-    def it_has_add_method_that_appends_to_end(self):
+    def it_has_public_add_method_that_appends_to_end(self):
         parent = (
             a_parent().with_nsdecls().with_child(
                 an_oomChild()).with_child(
@@ -591,7 +637,7 @@ class DescribeZeroOrMore(object):
         parent.add_zomChild(zomChild_2)
         assert parent.xml == expected_xml_2
 
-    def it_has_add_method_that_inserts_into_sequence(self):
+    def it_has_public_add_method_that_inserts_into_sequence(self):
         parent = (
             a_parent().with_nsdecls().with_child(
                 an_oomChild()).with_child(
@@ -967,6 +1013,7 @@ class CT_OomChild(BaseOxmlElement):
     child element that can appear multiple times in sequence, but must appear
     at least once.
     """
+    optval = OptionalAttribute("w:optval", ST_String)
 
 
 class CT_ZomChild(BaseOxmlElement):
@@ -1020,7 +1067,7 @@ class CT_SimpleParentBuilder(BaseBuilder):
 class CT_OomChildBuilder(BaseBuilder):
     __tag__ = 'w:oomChild'
     __nspfxs__ = ('w',)
-    __attrs__ = ()
+    __attrs__ = ('w:optval',)
 
 
 class CT_OooChildBuilder(BaseBuilder):

--- a/tests/parts/test_hdrftr.py
+++ b/tests/parts/test_hdrftr.py
@@ -50,7 +50,7 @@ class DescribeFooterPart(object):
 
     def it_loads_default_footer_XML_from_a_template_to_help(self):
         # ---tests integration with OS---
-        xml_bytes = FooterPart._default_footer_xml()
+        xml_bytes = FooterPart._default_footer_xml().replace(b'\r\n', b'\n')
 
         assert xml_bytes.startswith(
             b"<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n<w:ftr\n"
@@ -119,7 +119,7 @@ class DescribeHeaderPart(object):
 
     def it_loads_default_header_XML_from_a_template_to_help(self):
         # ---tests integration with OS---
-        xml_bytes = HeaderPart._default_header_xml()
+        xml_bytes = HeaderPart._default_header_xml().replace(b'\r\n', b'\n')
 
         assert xml_bytes.startswith(
             b"<?xml version='1.0' encoding='UTF-8' standalone='yes'?>\n<w:hdr\n"

--- a/tests/unitutil/file.py
+++ b/tests/unitutil/file.py
@@ -36,6 +36,7 @@ def snippet_seq(name, offset=0, count=1024):
     path = os.path.join(test_file_dir, 'snippets', '%s.txt' % name)
     with open(path, 'rb') as f:
         text = f.read().decode('utf-8')
+        text = text.replace('\r\n', '\n')
     snippets = text.split('\n\n')
     start, end = offset, offset+count
     return tuple(snippets[start:end])


### PR DESCRIPTION
* Fixed `dir()` on `BaseOxmlElements` in Python 3.8
* Extended `ZeroOrMore` and `OneOrMore` with:
  * `add_X(new_child, successor_element=None)` that allows you to add a new element to the end of a list, or into an arbitrary location in list (by defining where to insert before)
  * `remove_X(target_child)` for removing specific element
* Extend `ZeroOrOne` with `set_X(new_child)`